### PR TITLE
Update glyph_brush to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["fonts/**"]
 [dependencies]
 glium = { version = "0.32", default-features = false }
 #glium = { path = "../glium", default-features = false }
-glyph_brush = "0.6"
+glyph_brush = "0.7"
 
 [dev-dependencies]
 glium = "0.32"

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -4,13 +4,22 @@ extern crate glium_glyph;
 use glium::glutin::{Api, GlProfile, GlRequest};
 use glium::{glutin, Surface};
 
-use glium_glyph::glyph_brush::{rusttype::Font, Section};
-use glium_glyph::GlyphBrush;
+use glium_glyph::glyph_brush::{
+    ab_glyph::FontRef, HorizontalAlign, Layout, Section, Text, VerticalAlign,
+};
+use glium_glyph::GlyphBrushBuilder;
 
 use glutin::event::{Event, WindowEvent};
 use glutin::event_loop::{ControlFlow, EventLoop};
 
 pub fn main() {
+    if cfg!(target_os = "linux") {
+        // winit wayland has rendering problems on some setups
+        if std::env::var("WINIT_UNIX_BACKEND").is_err() {
+            std::env::set_var("WINIT_UNIX_BACKEND", "x11");
+        }
+    }
+
     let event_loop = EventLoop::new();
     let window = glutin::window::WindowBuilder::new();
     let context = glutin::ContextBuilder::new()
@@ -20,9 +29,9 @@ pub fn main() {
     let display = glium::Display::new(window, context, &event_loop).unwrap();
 
     let dejavu: &[u8] = include_bytes!("../fonts/DejaVuSans-2.37.ttf");
-    let fonts = vec![Font::from_bytes(dejavu).unwrap()];
+    let dejavu_font = FontRef::try_from_slice(dejavu).unwrap();
 
-    let mut glyph_brush = GlyphBrush::new(&display, fonts);
+    let mut glyph_brush = GlyphBrushBuilder::using_font(dejavu_font).build(&display);
 
     event_loop.run(move |event, _tgt, control_flow| {
         match event {
@@ -36,18 +45,22 @@ pub fn main() {
         }
         let screen_dims = display.get_framebuffer_dimensions();
 
-        glyph_brush.queue(Section {
-            text: "Hello, World!",
-            bounds: (screen_dims.0 as f32, screen_dims.1 as f32 / 2.0),
-            ..Section::default()
-        });
-        glyph_brush.queue(Section {
-            text: "This is in the middle of the screen",
-            bounds: (screen_dims.0 as f32, screen_dims.1 as f32 / 2.0),
-            screen_position: (0.0, screen_dims.1 as f32 / 2.0),
-            scale: glyph_brush::rusttype::Scale::uniform(16.0),
-            ..Section::default()
-        });
+        glyph_brush.queue(
+            Section::default()
+                .add_text(Text::new("Hello, World!").with_scale(48.0))
+                .with_bounds((screen_dims.0 as f32, screen_dims.1 as f32 / 2.0)),
+        );
+        glyph_brush.queue(
+            Section::default()
+                .add_text(Text::new("This is in the middle of the screen").with_scale(48.0))
+                .with_screen_position((screen_dims.0 as f32 / 2.0, screen_dims.1 as f32 / 2.0))
+                .with_bounds((screen_dims.0 as f32, screen_dims.1 as f32))
+                .with_layout(
+                    Layout::default()
+                        .h_align(HorizontalAlign::Center)
+                        .v_align(VerticalAlign::Center),
+                ),
+        );
 
         let mut target = display.draw();
         target.clear_color_and_depth((1.0, 1.0, 1.0, 0.0), 1.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,12 @@ use glium::texture::texture2d::Texture2d;
 use glium::texture::{ClientFormat, RawImage2d};
 use glium::{Program, Surface};
 
-use glyph_brush::rusttype::{Rect, SharedBytes};
+use glyph_brush::ab_glyph::{point, Font};
 use glyph_brush::{
-    rusttype::{point, Font},
-    BrushAction, BrushError, DefaultSectionHasher, FontId, GlyphCruncher, GlyphPositioner,
-    PositionedGlyphIter, VariedSection,
+    BrushAction, BrushError, DefaultSectionHasher, FontId, GlyphCruncher, GlyphPositioner, Section,
+    SectionGlyphIter,
 };
+use glyph_brush::{Extra, Rectangle};
 
 #[derive(Copy, Clone, Debug)]
 struct GlyphVertex {
@@ -52,16 +52,16 @@ struct InstanceVertex {
 
 implement_vertex!(InstanceVertex, v);
 
-fn rect_to_rect(rect: Rect<u32>) -> glium::Rect {
+fn rect_to_rect(rect: Rectangle<u32>) -> glium::Rect {
     glium::Rect {
-        left: rect.min.x,
-        bottom: rect.min.y,
+        left: rect.min[0],
+        bottom: rect.min[1],
         width: rect.width(),
         height: rect.height(),
     }
 }
 
-fn update_texture(tex: &Texture2d, rect: Rect<u32>, tex_data: &[u8]) {
+fn update_texture(tex: &Texture2d, rect: Rectangle<u32>, tex_data: &[u8]) {
     let image = RawImage2d {
         data: std::borrow::Cow::Borrowed(tex_data),
         format: ClientFormat::U8,
@@ -77,15 +77,14 @@ fn to_vertex(
         mut tex_coords,
         pixel_coords,
         bounds,
-        color,
-        z,
+        extra,
     }: glyph_brush::GlyphVertex,
 ) -> GlyphVertex {
     let gl_bounds = bounds;
 
-    let mut gl_rect = Rect {
-        min: point(pixel_coords.min.x as f32, pixel_coords.min.y as f32),
-        max: point(pixel_coords.max.x as f32, pixel_coords.max.y as f32),
+    let mut gl_rect = glyph_brush::ab_glyph::Rect {
+        min: point(pixel_coords.min.x, pixel_coords.min.y),
+        max: point(pixel_coords.max.x, pixel_coords.max.y),
     };
 
     // handle overlapping bounds, modify uv_rect to preserve texture aspect
@@ -111,11 +110,11 @@ fn to_vertex(
     }
 
     GlyphVertex {
-        left_top: [gl_rect.min.x, gl_rect.max.y, z],
+        left_top: [gl_rect.min.x, gl_rect.max.y, extra.z],
         right_bottom: [gl_rect.max.x, gl_rect.min.y],
         tex_left_top: [tex_coords.min.x, tex_coords.max.y],
         tex_right_bottom: [tex_coords.max.x, tex_coords.min.y],
-        color,
+        color: extra.color,
     }
 }
 
@@ -174,8 +173,8 @@ fn to_vertex(
 /// the previous draw call.
 */
 
-pub struct GlyphBrush<'font, 'a, H: BuildHasher = DefaultSectionHasher> {
-    glyph_brush: glyph_brush::GlyphBrush<'font, GlyphVertex, H>,
+pub struct GlyphBrush<'a, F: Font, H: BuildHasher = DefaultSectionHasher> {
+    glyph_brush: glyph_brush::GlyphBrush<GlyphVertex, Extra, F, H>,
     params: glium::DrawParameters<'a>,
     program: Program,
     texture: Texture2d,
@@ -184,13 +183,13 @@ pub struct GlyphBrush<'font, 'a, H: BuildHasher = DefaultSectionHasher> {
     instances: glium::VertexBuffer<InstanceVertex>,
 }
 
-impl<'font, 'p> GlyphBrush<'font, 'p> {
-    pub fn new<'a: 'font, F: Facade, V: Into<Vec<Font<'a>>>>(facade: &F, fonts: V) -> Self {
+impl<'p, F: Font> GlyphBrush<'p, F> {
+    pub fn new<C: Facade, V: Into<Vec<F>>>(facade: &C, fonts: V) -> Self {
         GlyphBrushBuilder::using_fonts(fonts).build(facade)
     }
 }
 
-impl<'font, 'p, H: BuildHasher> GlyphBrush<'font, 'p, H> {
+impl<'p, F: Font + Sync, H: BuildHasher> GlyphBrush<'p, F, H> {
     /// Queues a section/layout to be drawn by the next call of
     /// [`draw_queued`](struct.GlyphBrush.html#method.draw_queued). Can be called multiple times
     /// to queue multiple sections for drawing.
@@ -203,7 +202,7 @@ impl<'font, 'p, H: BuildHasher> GlyphBrush<'font, 'p, H> {
     pub fn queue_custom_layout<'a, S, G>(&mut self, section: S, custom_layout: &G)
     where
         G: GlyphPositioner,
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, Section<'a>>>,
     {
         self.glyph_brush.queue_custom_layout(section, custom_layout)
     }
@@ -216,7 +215,7 @@ impl<'font, 'p, H: BuildHasher> GlyphBrush<'font, 'p, H> {
     #[inline]
     pub fn queue<'a, S>(&mut self, section: S)
     where
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, Section<'a>>>,
     {
         self.glyph_brush.queue(section)
     }
@@ -233,9 +232,9 @@ impl<'font, 'p, H: BuildHasher> GlyphBrush<'font, 'p, H> {
     	*/
 
     #[inline]
-    pub fn draw_queued<F: Facade + Deref<Target = Context>, S: Surface>(
+    pub fn draw_queued<C: Facade + Deref<Target = Context>, S: Surface>(
         &mut self,
-        facade: &F,
+        facade: &C,
         surface: &mut S,
     ) {
         let dims = facade.get_framebuffer_dimensions();
@@ -297,10 +296,10 @@ impl<'font, 'p, H: BuildHasher> GlyphBrush<'font, 'p, H> {
     /// ```
     	*/
 
-    pub fn draw_queued_with_transform<F: Facade + Deref<Target = Context>, S: Surface>(
+    pub fn draw_queued_with_transform<C: Facade + Deref<Target = Context>, S: Surface>(
         &mut self,
         transform: [[f32; 4]; 4],
-        facade: &F,
+        facade: &C,
         surface: &mut S,
     ) {
         let mut brush_action;
@@ -360,74 +359,36 @@ impl<'font, 'p, H: BuildHasher> GlyphBrush<'font, 'p, H> {
             .unwrap();
     }
 
-    /*
     /// Adds an additional font to the one(s) initially added on build.
     ///
     /// Returns a new [`FontId`](struct.FontId.html) to reference this font.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// # extern crate gfx;
-    /// # extern crate gfx_window_glutin;
-    /// # extern crate glutin;
-    /// extern crate gfx_glyph;
-    /// use gfx_glyph::{GlyphBrushBuilder, Section};
-    /// # fn main() {
-    /// # let events_loop = glutin::EventsLoop::new();
-    /// # let (_window, _device, mut gfx_factory, gfx_color, gfx_depth) =
-    /// #     gfx_window_glutin::init::<gfx::format::Srgba8, gfx::format::Depth>(
-    /// #         glutin::WindowBuilder::new(),
-    /// #         glutin::ContextBuilder::new(),
-    /// #         &events_loop);
-    /// # let mut gfx_encoder: gfx::Encoder<_, _> = gfx_factory.create_command_buffer().into();
-    ///
-    /// // dejavu is built as default `FontId(0)`
-    /// let dejavu: &[u8] = include_bytes!("../../fonts/DejaVuSans.ttf");
-    /// let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(dejavu).build(gfx_factory.clone());
-    ///
-    /// // some time later, add another font referenced by a new `FontId`
-    /// let open_sans_italic: &[u8] = include_bytes!("../../fonts/OpenSans-Italic.ttf");
-    /// let open_sans_italic_id = glyph_brush.add_font_bytes(open_sans_italic);
-    /// # glyph_brush.draw_queued(&mut gfx_encoder, &gfx_color, &gfx_depth).unwrap();
-    /// # let _ = open_sans_italic_id;
-    /// # }
-    /// ```
-    	*/
-
-    pub fn add_font_bytes<'a: 'font, B: Into<SharedBytes<'a>>>(&mut self, font_data: B) -> FontId {
-        self.glyph_brush.add_font_bytes(font_data)
-    }
-
-    /// Adds an additional font to the one(s) initially added on build.
-    ///
-    /// Returns a new [`FontId`](struct.FontId.html) to reference this font.
-    pub fn add_font<'a: 'font>(&mut self, font_data: Font<'a>) -> FontId {
+    pub fn add_font<I: Into<F>>(&mut self, font_data: I) -> FontId {
         self.glyph_brush.add_font(font_data)
     }
 }
 
-impl<'font, 'l, H: BuildHasher> GlyphCruncher<'font> for GlyphBrush<'font, 'l, H> {
-    fn pixel_bounds_custom_layout<'a, S, L>(
+impl<'l, F: Font, H: BuildHasher> GlyphCruncher<F> for GlyphBrush<'l, F, H> {
+    fn glyph_bounds_custom_layout<'a, S, L>(
         &mut self,
         section: S,
         custom_layout: &L,
-    ) -> Option<Rect<i32>>
+    ) -> Option<glyph_brush::ab_glyph::Rect>
     where
         L: GlyphPositioner + Hash,
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, Section<'a>>>,
     {
         self.glyph_brush
-            .pixel_bounds_custom_layout(section, custom_layout)
+            .glyph_bounds_custom_layout(section, custom_layout)
     }
+
     fn glyphs_custom_layout<'a, 'b, S, L>(
         &'b mut self,
         section: S,
         custom_layout: &L,
-    ) -> PositionedGlyphIter<'b, 'font>
+    ) -> SectionGlyphIter<'b>
     where
         L: GlyphPositioner + Hash,
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, Section<'a>>>,
     {
         self.glyph_brush
             .glyphs_custom_layout(section, custom_layout)
@@ -437,7 +398,7 @@ impl<'font, 'l, H: BuildHasher> GlyphCruncher<'font> for GlyphBrush<'font, 'l, H
     ///
     /// The `FontId` corresponds to the index of the font data.
     #[inline]
-    fn fonts(&self) -> &[Font<'font>] {
+    fn fonts(&self) -> &[F] {
         self.glyph_brush.fonts()
     }
 }


### PR DESCRIPTION
I mostly replicated the changes [made to the `gfx_glyph` crate](https://github.com/alexheretic/glyph-brush/commit/59a4cf16419c4a28c4b6383d8c1e0194031dff1c).

I also updated the example code to a) demonstrate how to use `GlyphBrushBuilder` and the new builder API for `Section`s, b) fix poor text rendering on Linux by setting `WINIT_UNIX_BACKEND=x11`. (I have Fedora 37 with fairly recent versions of Wayland/GNOME and I see terrible aliasing artifacts regardless of the font used. Switching to X11 completely resolves the issue. glyph_brush's [own example](https://github.com/alexheretic/glyph-brush/blob/main/glyph-brush/examples/opengl.rs#L56) also does this.)

 